### PR TITLE
Iss7

### DIFF
--- a/Aufgabensammlung (inoffiziell)/Typ 2 Aufgaben/Typ2 LaTeX file assistent 3.1.py
+++ b/Aufgabensammlung (inoffiziell)/Typ 2 Aufgaben/Typ2 LaTeX file assistent 3.1.py
@@ -243,8 +243,7 @@ def control_cb():
 		for all in files:
 			if all.endswith('.tex') or all.endswith('.ltx'):
 				if not ('Gesamtdokument' in all) and not ('Teildokument' in all):
-					file=open(os.path.join(root,all), 'rb')
-					#import pdb; pdb.set_trace()
+					file=open(os.path.join(root,all), 'r', encoding='ISO-8859-1')
 					for i, line in enumerate(file):
 						if not line == "\n":
 							beispieldaten_dateipfad[os.path.join(all)]=line

--- a/Aufgabensammlung (inoffiziell)/Typ 2 Aufgaben/Typ2 LaTeX file assistent 3.1.py
+++ b/Aufgabensammlung (inoffiziell)/Typ 2 Aufgaben/Typ2 LaTeX file assistent 3.1.py
@@ -243,7 +243,8 @@ def control_cb():
 		for all in files:
 			if all.endswith('.tex') or all.endswith('.ltx'):
 				if not ('Gesamtdokument' in all) and not ('Teildokument' in all):
-					file=open(os.path.join(root,all))
+					file=open(os.path.join(root,all), 'rb')
+					#import pdb; pdb.set_trace()
 					for i, line in enumerate(file):
 						if not line == "\n":
 							beispieldaten_dateipfad[os.path.join(all)]=line

--- a/Aufgabensammlung (inoffiziell)/Typ 2 Aufgaben/Typ2 LaTeX file assistent 3.1.py
+++ b/Aufgabensammlung (inoffiziell)/Typ 2 Aufgaben/Typ2 LaTeX file assistent 3.1.py
@@ -256,7 +256,7 @@ def control_cb():
 			while_cnt=0
 			if all.endswith('.tex') or all.endswith('.ltx'):
 				if not ('Gesamtdokument' in all) and not ('Teildokument' in all):
-					file=open(os.path.join(root,all))
+					file=open(os.path.join(root,all), encoding='ISO-8859-1')
 					dirname, filename= os.path.split(root)
 					dirname=root
 					while filename != 'Aufgabensammlung (offiziell)':
@@ -299,7 +299,7 @@ def control_cb():
 	
 	
 	filename_teildokument = os.path.join(os.path.dirname('__file__'),'Teildokument','Teildokument.tex')
-	file=open(filename_teildokument,"w")
+	file=open(filename_teildokument,"w", encoding='ISO-8859-1')
 	file.write("\documentclass[a4paper,12pt]{report}\n\n"
 	"\\usepackage{geometry}\n"	
 	"\geometry{a4paper,left=18mm,right=18mm, top=3cm, bottom=2cm}\n\n" 
@@ -418,7 +418,7 @@ def control_cb():
 			for key, value in beispieldaten_dateipfad.items():
 				key=key.replace('\\','/')
 				if dateien in value:
-					file=open(filename_teildokument,"a")
+					file=open(filename_teildokument,"a", encoding='ISO-8859-1')
 					if 'Aufgabensammlung (offiziell)' in key:
 						file.write('\input{"../../../'+key+'"}%\n'
 						'\hrule  \leer\n\n')
@@ -427,7 +427,7 @@ def control_cb():
 						'\hrule  \leer\n\n')
 					file.close()
 		loop_dateien +=1
-	file=open(filename_teildokument,"a")
+	file=open(filename_teildokument,"a", encoding='ISO-8859-1')
 	file.write('\shorthandoff{"}\n'
 	"\end{document}")
 	file.close()	
@@ -446,6 +446,7 @@ def control_cb():
 	else:
 		print("Insgesamt wurde(n) " + str(len(gesammeltedateien)) + " Beispiel(e) gefunden. Entsprechende LaTeX-Datei wird ausgegeben...")
 		hauptfenster.destroy()
+		import pdb; pdb.set_trace()
 		os.system(filename_teildokument)
 		sys.exit(0)
 		

--- a/issues.md
+++ b/issues.md
@@ -38,9 +38,9 @@ Exception in Tkinter callback
 Traceback (most recent call last):
   File "/usr/lib/python3.5/tkinter/__init__.py", line 1562, in __call__
     return self.func(*args)
-  File "Aufgabensammlung (inoffiziell)/Typ 1 Aufgaben/Typ1 LaTeX file assistent 4.0.py", line 297, in control_cb
+  File "Typ2 LaTeX file assistent 3.1.py", line 247, in control_cb
     for i, line in enumerate(file):
   File "/usr/lib/python3.5/codecs.py", line 321, in decode
     (result, consumed) = self._buffer_decode(data, self.errors, final)
-UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc4 in position 32: invalid continuation byte
+UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfc in position 223: invalid start byte
 ```

--- a/issues.md
+++ b/issues.md
@@ -44,3 +44,4 @@ Traceback (most recent call last):
     (result, consumed) = self._buffer_decode(data, self.errors, final)
 UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfc in position 223: invalid start byte
 ```
+0xfc seems to be a ü


### PR DESCRIPTION
fixed Issue 7: Typ2: Searching

changed `file=open(os.path.join(root,all))` 
to `file=open(os.path.join(root,all), 'r', encoding='ISO-8859-1')`

@chrisiweb please check if it still works with windows
if so, let me know, that i can merge into master